### PR TITLE
The buttons of #fbToolbarInner disappear when switching to the Console Panel (FB 1.12)

### DIFF
--- a/chrome/content/aceEditor.js
+++ b/chrome/content/aceEditor.js
@@ -512,13 +512,19 @@ Firebug.largeCommandLineEditor = {
     set value(val) {
         if (this._setValue)
             return this.setValue(val);
-        if (arguments.callee.caller == Firebug.CommandLine.commandHistory.onMouseUp) {
-            var mode = Firebug.Ace.win2.editor.session.getMode()
-            if (mode.setCellText)
-                return mode.setCellText(val)
-            return this.setValue(val);
-        }
         return val;
+    },
+
+    onSelectHistoryEntry: function(ev) {
+        var index = ev.target.value;
+        if (index == undefined)
+            return;
+        var val = Firebug.CommandLine.commandHistory.commands[index];
+        var mode = Firebug.Ace.win2.editor.session.getMode();
+        if (mode.setCellText)
+            mode.setCellText(val);
+        else
+            Firebug.largeCommandLineEditor.setValue(val);
     },
 
     addEventListener: function() {
@@ -743,6 +749,9 @@ Firebug.largeCommandLineEditor = {
 	}
 
 };
+
+Firebug.chrome.$("fbCommandHistory").addEventListener("mouseup",
+    Firebug.largeCommandLineEditor.onSelectHistoryEntry);
 
 var inputNumber = 0;
 /***********************************************************/


### PR DESCRIPTION
With Firebug 1.12 beta 4, the buttons of #fbToolbarInner (Clear, Profile, Persist, etc.) disappear when switching to the Console Panel.

Steps to reproduce: 
1. Install Firebug 1.12b4 + Acebug Editor
2. Restart Firefox
3. Enable Firebug on this page
4. Enable the Console panel, refresh
5. Switch to the HTML panel
6. Switch back to the Console panel
   |=> no buttons of #fbToolbarInner

This is due to the use of the strict mode in Firebug + the use of arguments.callee.caller in aceEditor.js.

You'll find attached a fix. Don't hesitate to modify it at your convenience. Hope it will help!

Florent
